### PR TITLE
Redirect gallery to static version

### DIFF
--- a/views/main.js
+++ b/views/main.js
@@ -31,7 +31,7 @@ module.exports = function (params, state, send) {
     </div>
     <div class='row'>
       <div class='callout'>
-        <a class='link' href='/examples'>examples</a>
+        <a class='link' href='https://regl-project.github.io/regl/www/gallery.html'>examples</a>
         <span class ='color-block-small orange'></span>
       </div>
       <div class='callout'>


### PR DESCRIPTION
This PR redirects the wzrd.in-based gallery to [the static version](https://regl-project.github.io/regl/www/gallery.html) since it seems like wzrd.in is (possibly?) down permanently. Feedback welcome, but this seems preferable to the gallery just failing entirely.

It seems though like it requires surge permissions in order to deploy this though, so merging won't actually complete the redirect.

/cc @mikolalysenko @gregtatum @dy 